### PR TITLE
adding bin script for npx command

### DIFF
--- a/bin/shadcn-prose.js
+++ b/bin/shadcn-prose.js
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const path = require("path");
+
+const COMPONENTS_JSON = path.join(process.cwd(), "components.json");
+const SOURCE_CSS = path.join(__dirname, "..", "website", "app", "prose.css");
+
+function exitWithError(msg) {
+  console.error(msg);
+  process.exit(1);
+}
+
+// 1. Locate components.json in the root
+if (!fs.existsSync(COMPONENTS_JSON)) {
+  exitWithError("components.json not found in project root!");
+}
+
+// 2. Read and parse components.json
+let components;
+try {
+  components = JSON.parse(fs.readFileSync(COMPONENTS_JSON, "utf8"));
+} catch (err) {
+  exitWithError("Error parsing components.json: " + err.message);
+}
+
+// 3. Find the "tailwind" object
+const tailwind = components["tailwind"];
+if (!tailwind) {
+  exitWithError('No "tailwind" object found in components.json!');
+}
+
+// 4. Find the css key (path to CSS file)
+const cssPath = tailwind["css"];
+if (!cssPath) {
+  exitWithError('No "css" key found inside "tailwind" object!');
+}
+
+const resolvedCssPath = path.resolve(process.cwd(), cssPath);
+
+if (!fs.existsSync(resolvedCssPath)) {
+  exitWithError(`CSS file not found at path: ${resolvedCssPath}`);
+}
+
+// 5. Read source CSS file, remove the first line, prepend a comment
+if (!fs.existsSync(SOURCE_CSS)) {
+  exitWithError("Source CSS file not found: " + SOURCE_CSS);
+}
+
+let sourceCssContent = fs.readFileSync(SOURCE_CSS, "utf8");
+let lines = sourceCssContent.split(/\r?\n/);
+
+// Remove the first line as we don't need to re-import tailwind
+lines.shift();
+
+const cssToAppend = `
+/* Appended by shadcn-prose */
+${lines.join("\n")}
+`;
+
+// 6. Append to the destination CSS file
+fs.appendFileSync(resolvedCssPath, cssToAppend, "utf8");
+
+console.log("Successfully appended CSS to:", cssPath);

--- a/package.json
+++ b/package.json
@@ -7,11 +7,13 @@
     "url": "git+https://github.com/haydenbleasel/shadcn-prose.git"
   },
   "files": [
-    "website/app/prose.css"
+    "website/app/prose.css",
+    "bin/shadcn-prose.js"
   ],
   "exports": {
     ".": "./website/app/prose.css"
   },
+  "bin": "./bin/shadcn-prose.js",
   "keywords": [
     "shadcn",
     "prose",


### PR DESCRIPTION
I have only done local testing, but in reality this is a simple file check command and adding css to their globals file. It locates the `components.json` file in their repo, uses that to determine where the `globals.css` file is located, and then appends the styles from the `prose.css` file. 

When deployed, this should allow users to simply write `npx shadcn-prose` and then their css file should be updated (hopefully).